### PR TITLE
Forward compatibility with jenkinsci/jenkins#8503

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,21 +5,21 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.11</version>
+    <version>4.73</version>
     <relativePath />
   </parent>
 
   <name>VectorCAST Coverage</name>
   <description>Display VectorCAST coverage in Jenkins</description>
   <artifactId>vectorcast-coverage</artifactId>
-  <version>0.22-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
-  <url>https://github.com/jenkinsci/vectorcast-coverage-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://opensource.org/licenses/MIT</url>
+      <url>https://opensource.org/license/mit/</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -39,19 +39,17 @@
   </developers>
 
   <properties>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jenkins.version>1.625.3</jenkins.version>
-    <java.level>8</java.level>
-    <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+    <revision>0.22</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.387.3</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/vectorcast-coverage-plugin.git</connection>
-    <developerConnection>scm:git:https://github.com/jenkinsci/vectorcast-coverage-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/vectorcast-coverage-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
 
   <repositories>
@@ -61,7 +59,29 @@
     </repository>
   </repositories>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2446.v2e9fd3b_d8c81</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+    <dependency>
+      <groupId>io.github.x-stream</groupId>
+      <artifactId>mxparser</artifactId>
+      <version>1.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <version>2.12.5</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-digester3</artifactId>
@@ -70,76 +90,20 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>dashboard-view</artifactId>
-      <version>2.16</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>2.8</version>
+      <exclusions>
+        <!-- Provided by Jenkins core -->
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.0-M1</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-        
-          <!-- Attention Eclipse users: if you see an error here, you have to install the M2E buildhelper plugin.-->
-          <execution>
-            <id>add-localizer-source-folder</id>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated-sources/localizer</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.4</version>
-        <configuration>
-          <xmlOutput>true</xmlOutput>
-          <failOnError>${findbugs.failOnError}</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <id>run-findbugs</id>
-            <phase>verify</phase> 
-            <goals>
-              <goal>check</goal> 
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  <pluginManagement>
-    <plugins>
-    </plugins>
-  </pluginManagement>
-  </build>
 
   <pluginRepositories>
     <pluginRepository>

--- a/src/main/java/com/vectorcast/plugins/vectorcastcoverage/VectorCASTPublisher.java
+++ b/src/main/java/com/vectorcast/plugins/vectorcastcoverage/VectorCASTPublisher.java
@@ -1,5 +1,6 @@
 package com.vectorcast.plugins.vectorcastcoverage;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -215,6 +216,7 @@ public class VectorCASTPublisher extends Recorder implements SimpleBuildStep {
         performImpl(run, workspace, listener);
     }
 
+    @SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION", justification = "TODO needs triage")
     public boolean performImpl(Run<?, ?> run, FilePath workspace, TaskListener listener) throws InterruptedException, IOException {
         final PrintStream logger = listener.getLogger();
         
@@ -363,6 +365,7 @@ public class VectorCASTPublisher extends Recorder implements SimpleBuildStep {
     }
     
     
+	@SuppressFBWarnings(value = "DCN_NULLPOINTER_EXCEPTION", justification = "TODO needs triage")
 	private void checkThreshold(Run<?, ?> run,
 		final PrintStream logger, EnvVars env, final VectorCASTBuildAction action) {
 			

--- a/src/test/java/com/vectorcast/plugins/vectorcastcoverage/portlet/VectorCASTLoadDataHudsonTest.java
+++ b/src/test/java/com/vectorcast/plugins/vectorcastcoverage/portlet/VectorCASTLoadDataHudsonTest.java
@@ -183,7 +183,7 @@ public class VectorCASTLoadDataHudsonTest extends HudsonTestCase {
      */
     static class CopyResourceToWorkspaceBuilder extends Builder {
 
-        private final InputStream content;
+        private transient final InputStream content;
         private final String fileName;
 
         /**


### PR DESCRIPTION
Without dropping support for existing cores (where this library will simply be ignored in favor of core's copy), add forward compatibility for https://github.com/jenkinsci/jenkins/pull/8503 by bundling XML Pull Parser 3rd Edition within this plugin's HPI file rather than relying on core's copy, thereby enabling us to remove this library from core.

### Testing done

See https://github.com/jenkinsci/testng-plugin-plugin/pull/246.